### PR TITLE
Add make: command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 build
 composer.lock
 docs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 build
 composer.lock
 docs

--- a/README.md
+++ b/README.md
@@ -18,6 +18,30 @@ You can install the package via composer:
 composer require spatie/laravel-view-models
 ```
 
+For Laravel versions 5.5+, the ServiceProvider will be automatically discovered.
+Otherwise, add to `config/app.php`, under `providers` key:
+
+```php
+    'providers' => [
+        (...)
+        /*
+         * Package Service Providers...
+         */
+        \Spatie\ViewModels\Providers\ViewModelsServiceProvider::class,
+```
+
+To generate a new ViewModel, into `App\ViewModels` namespace:
+
+```bash
+php artisan make:view-model HomepageViewModel
+```
+
+or into a custom namespace, say, `App\Blog`
+
+```bash
+php artisan make:view-model Blog/PostsViewModel
+```
+
 ## Usage
 
 A view model is a class where you can put some complex logic for your views. This will make your controllers a bit lighter.  You can create a view model by extending the provided `Spatie\ViewModels\ViewModel`.

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,13 @@
             "Spatie\\ViewModels\\Tests\\": "tests"
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Spatie\\ViewModels\\Providers\\ViewModelsServiceProvider"
+            ]
+        }
+    },
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"

--- a/src/Console/ViewModelMakeCommand.php
+++ b/src/Console/ViewModelMakeCommand.php
@@ -7,54 +7,26 @@ use Symfony\Component\Console\Input\InputOption;
 
 class ViewModelMakeCommand extends GeneratorCommand
 {
-    /**
-     * The console command name.
-     *
-     * @var string
-     */
     protected $name = 'make:view-model';
 
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
     protected $description = 'Create a new ViewModel class';
 
-    /**
-     * The type of class being generated.
-     *
-     * @var string
-     */
     protected $type = 'ViewModel';
 
-    /**
-     * Execute the console command.
-     *
-     * @return void
-     */
     public function handle()
     {
-        if (parent::handle() === false && ! $this->option('force')) {
-            return;
+        if (parent::handle() === false) {
+            if (! $this->option('force')) {
+                return;
+            }
         }
     }
 
-    /**
-     * Get the stub file for the generator.
-     *
-     * @return string
-     */
     protected function getStub()
     {
         return __DIR__.'/../../stubs/DummyViewModel.stub';
     }
 
-    /**
-     * Get the console command options.
-     *
-     * @return array
-     */
     protected function getOptions(): array
     {
         return [

--- a/src/Console/ViewModelMakeCommand.php
+++ b/src/Console/ViewModelMakeCommand.php
@@ -22,6 +22,11 @@ class ViewModelMakeCommand extends GeneratorCommand
         }
     }
 
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\ViewModels';
+    }
+
     protected function getStub()
     {
         return __DIR__.'/../../stubs/DummyViewModel.stub';

--- a/src/Console/ViewModelMakeCommand.php
+++ b/src/Console/ViewModelMakeCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Spatie\ViewModels\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class ViewModelMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:view-model';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new ViewModel class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'ViewModel';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (parent::handle() === false && ! $this->option('force')) {
+            return;
+        }
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/../../stubs/DummyViewModel.stub';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions(): array
+    {
+        return [
+            ['force', null, InputOption::VALUE_NONE, 'Create the class even if the view-model already exists'],
+        ];
+    }
+}

--- a/src/Console/ViewModelMakeCommand.php
+++ b/src/Console/ViewModelMakeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\ViewModels\Console;
 
+use Illuminate\Support\Str;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -22,14 +23,18 @@ class ViewModelMakeCommand extends GeneratorCommand
         }
     }
 
-    protected function getDefaultNamespace($rootNamespace)
-    {
-        return $rootNamespace.'\ViewModels';
-    }
-
     protected function getStub()
     {
         return __DIR__.'/../../stubs/DummyViewModel.stub';
+    }
+
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        if ($this->isCustomNamespace()) {
+            return $rootNamespace;
+        }
+
+        return $rootNamespace.'\ViewModels';
     }
 
     protected function getOptions(): array
@@ -37,5 +42,10 @@ class ViewModelMakeCommand extends GeneratorCommand
         return [
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the view-model already exists'],
         ];
+    }
+
+    protected function isCustomNamespace(): bool
+    {
+        return Str::contains($this->argument('name'), '/');
     }
 }

--- a/src/Providers/ViewModelsServiceProvider.php
+++ b/src/Providers/ViewModelsServiceProvider.php
@@ -7,25 +7,12 @@ use Spatie\ViewModels\Console\ViewModelMakeCommand;
 
 class ViewModelsServiceProvider extends ServiceProvider
 {
-    /**
-     * Bootstrap services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        //
-    }
-
-    /**
-     * Register services.
-     *
-     * @return void
-     */
     public function register()
     {
-        $this->commands([
-            ViewModelMakeCommand::class,
-        ]);
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                ViewModelMakeCommand::class,
+            ]);
+        }
     }
 }

--- a/src/Providers/ViewModelsServiceProvider.php
+++ b/src/Providers/ViewModelsServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\ViewModels\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Spatie\ViewModels\Console\ViewModelMakeCommand;
+
+class ViewModelsServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->commands([
+            ViewModelMakeCommand::class,
+        ]);
+    }
+}

--- a/stubs/DummyViewModel.stub
+++ b/stubs/DummyViewModel.stub
@@ -6,9 +6,8 @@ use Spatie\ViewModels\ViewModel;
 
 class DummyClass extends ViewModel
 {
-    protected $ignore = [
-        'ignoredMethods',
-    ];
-
-    public $property = 'abc';
+    public function __construct()
+    {
+        //
+    }
 }

--- a/stubs/DummyViewModel.stub
+++ b/stubs/DummyViewModel.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace DummyNamespace;
+
+use Spatie\ViewModels\ViewModel;
+
+class DummyClass extends ViewModel
+{
+    protected $ignore = [
+        'ignoredMethods',
+    ];
+
+    public $property = 'abc';
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\View;
 use Symfony\Component\HttpFoundation\Response;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Spatie\ViewModels\Providers\ViewModelsServiceProvider;
 
 class TestCase extends OrchestraTestCase
 {
@@ -30,5 +31,10 @@ class TestCase extends OrchestraTestCase
     protected function getResponseBody(Response $response): array
     {
         return json_decode($response->getContent(), true);
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [ ViewModelsServiceProvider::class ];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -35,6 +35,6 @@ class TestCase extends OrchestraTestCase
 
     protected function getPackageProviders($app)
     {
-        return [ ViewModelsServiceProvider::class ];
+        return [ViewModelsServiceProvider::class];
     }
 }

--- a/tests/ViewModelMakeCommandTest.php
+++ b/tests/ViewModelMakeCommandTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\ViewModels\Tests;
+
+use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Artisan;
+
+class ViewModelMakeCommandTest extends TestCase
+{
+    /** @test */
+    public function command_returns_signal_zero()
+    {
+        $a = Artisan::call('make:view-model', [ 'name' => 'PostsViewModel']);
+
+        $b = Artisan::output();
+
+        dd($a, $b);
+    }
+}

--- a/tests/ViewModelMakeCommandTest.php
+++ b/tests/ViewModelMakeCommandTest.php
@@ -2,20 +2,54 @@
 
 namespace Spatie\ViewModels\Tests;
 
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Artisan;
 
 class ViewModelMakeCommandTest extends TestCase
 {
     /** @test */
-    public function command_returns_signal_zero()
+    public function creates_file_in_default_folder()
     {
         $exitCode = Artisan::call('make:view-model', [
-            'name' => 'PostsViewModel',
+            'name' => 'HomeViewModel',
             '--force' => true,
         ]);
 
         $this->assertEquals(0, $exitCode);
 
         $this->assertContains('ViewModel created successfully.', Artisan::output());
+
+        $shouldOutputFilePath = $this->app['path'] . '/ViewModels/HomeViewModel.php';
+
+        $this->assertTrue(File::exists($shouldOutputFilePath), 'File exists in default app/ViewModels folder');
+
+        $contents = File::get($shouldOutputFilePath);
+
+        $this->assertContains('namespace App\ViewModels;', $contents);
+
+        $this->assertContains('class HomeViewModel extends ViewModel', $contents);
+    }
+
+    /** @test */
+    public function creates_file_in_custom_folder()
+    {
+        $exitCode = Artisan::call('make:view-model', [
+            'name' => 'Blog/PostsViewModel',
+            '--force' => true,
+        ]);
+
+        $this->assertEquals(0, $exitCode);
+
+        $this->assertContains('ViewModel created successfully.', Artisan::output());
+
+        $shouldOutputFilePath = $this->app['path'] . '/Blog/PostsViewModel.php';
+
+        $this->assertTrue(File::exists($shouldOutputFilePath), 'File exists in custom app/Blog folder');
+
+        $contents = File::get($shouldOutputFilePath);
+
+        $this->assertContains('namespace App\Blog;', $contents);
+
+        $this->assertContains('class PostsViewModel extends ViewModel', $contents);
     }
 }

--- a/tests/ViewModelMakeCommandTest.php
+++ b/tests/ViewModelMakeCommandTest.php
@@ -2,8 +2,6 @@
 
 namespace Spatie\ViewModels\Tests;
 
-use Illuminate\Http\Response;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Artisan;
 
 class ViewModelMakeCommandTest extends TestCase
@@ -11,10 +9,13 @@ class ViewModelMakeCommandTest extends TestCase
     /** @test */
     public function command_returns_signal_zero()
     {
-        $a = Artisan::call('make:view-model', [ 'name' => 'PostsViewModel']);
+        $exitCode = Artisan::call('make:view-model', [
+            'name' => 'PostsViewModel',
+            '--force' => true,
+        ]);
 
-        $b = Artisan::output();
+        $this->assertEquals(0, $exitCode);
 
-        dd($a, $b);
+        $this->assertContains('ViewModel created successfully.', Artisan::output());
     }
 }

--- a/tests/ViewModelMakeCommandTest.php
+++ b/tests/ViewModelMakeCommandTest.php
@@ -19,7 +19,7 @@ class ViewModelMakeCommandTest extends TestCase
 
         $this->assertContains('ViewModel created successfully.', Artisan::output());
 
-        $shouldOutputFilePath = $this->app['path'] . '/ViewModels/HomeViewModel.php';
+        $shouldOutputFilePath = $this->app['path'].'/ViewModels/HomeViewModel.php';
 
         $this->assertTrue(File::exists($shouldOutputFilePath), 'File exists in default app/ViewModels folder');
 
@@ -42,7 +42,7 @@ class ViewModelMakeCommandTest extends TestCase
 
         $this->assertContains('ViewModel created successfully.', Artisan::output());
 
-        $shouldOutputFilePath = $this->app['path'] . '/Blog/PostsViewModel.php';
+        $shouldOutputFilePath = $this->app['path'].'/Blog/PostsViewModel.php';
 
         $this->assertTrue(File::exists($shouldOutputFilePath), 'File exists in custom app/Blog folder');
 


### PR DESCRIPTION
As mentioned in https://github.com/spatie/laravel-view-models/issues/4

feat(ViewModelMakeCommand):
- .gitignore added `.idea`
- composer.json added the service provider auto discovery key
- ViewModelMakeCommand, extending the base Generator command, as it's pretty similar
- ViewModelServiceProvider, registering the command
- Added DummyViewModelStub