### PR TITLE
Allow $data to be passed to view model

### DIFF
--- a/src/ViewModel.php
+++ b/src/ViewModel.php
@@ -19,6 +19,8 @@ abstract class ViewModel implements Arrayable, Responsable
 
     protected $view = '';
 
+    protected $data = [];
+
     public function toArray(): array
     {
         return $this
@@ -39,9 +41,10 @@ abstract class ViewModel implements Arrayable, Responsable
         return new JsonResponse($this->items());
     }
 
-    public function view(string $view): ViewModel
+    public function view(string $view, array $data = []): ViewModel
     {
         $this->view = $view;
+        $this->data = $data;
 
         return $this;
     }
@@ -66,7 +69,8 @@ abstract class ViewModel implements Arrayable, Responsable
                 return [$method->getName() => $this->createVariableFromMethod($method)];
             });
 
-        return $publicProperties->merge($publicMethods);
+
+        return $publicProperties->merge($publicMethods)->merge($this->data);
     }
 
     protected function shouldIgnore(string $methodName): bool

--- a/tests/ViewModelTest.php
+++ b/tests/ViewModelTest.php
@@ -112,4 +112,12 @@ class ViewModelTest extends TestCase
 
         $this->assertInstanceOf(JsonResponse::class, $response);
     }
+
+    /** @test */
+    public function it_will_allow_params_to_be_passed_to_view_method()
+    {
+        $array = $this->viewModel->view('test', ['name' => 'james'])->toArray();
+
+        $this->assertArrayHasKey('name', $array);
+    }
 }


### PR DESCRIPTION
This PR allows you the ability to pass data into the ViewModel from the Controller, I thought this was useful if you are passing certain parts of the request into the view. 

```php
public function show(UsersShowViewModel $viewModel, Request $request, Post $post)
{
    $response = $this->validate([
        //...
    ]);
   
    $viewModel->view('form', $response);
}
```