### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [7.4, 8.0, 8.1]
+                php: [8.2, 8.1, 8.0, 7.4]
                 laravel: [9.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
@@ -37,7 +37,7 @@ jobs:
             -   name: Install dependencies
                 run: |
                     composer remove --dev friendsofphp/php-cs-fixer --no-interaction --no-update
-                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                    composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.63" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
             -   name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "illuminate/support": "^8.0|^9.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.23|^7.0"
+        "orchestra/testbench": "^6.23|^7.0",
+        "phpunit/phpunit": "^9.4"
     },
     "autoload": {
         "psr-4": {

--- a/tests/ViewModelMakeCommandTest.php
+++ b/tests/ViewModelMakeCommandTest.php
@@ -17,7 +17,7 @@ class ViewModelMakeCommandTest extends TestCase
 
         $this->assertEquals(0, $exitCode);
 
-        $this->assertStringContainsString('ViewModel created successfully.', Artisan::output());
+        $this->assertMatchesRegularExpression('~ViewModel( \[.+\])? created successfully~', Artisan::output());
 
         $shouldOutputFilePath = $this->app['path'].'/ViewModels/HomeViewModel.php';
 
@@ -40,7 +40,7 @@ class ViewModelMakeCommandTest extends TestCase
 
         $this->assertEquals(0, $exitCode);
 
-        $this->assertStringContainsString('ViewModel created successfully.', Artisan::output());
+        $this->assertMatchesRegularExpression('~ViewModel( \[.+\])? created successfully~', Artisan::output());
 
         $shouldOutputFilePath = $this->app['path'].'/ViewModels/Blog/PostsViewModel.php';
 


### PR DESCRIPTION
## Summary

This PR adds PHP 8.2 to the tests workflow.  It also updates unit tests to support slightly different `Artisan` output in Laravel 9, and adds `PHPUnit ^9.4` to the required dependencies. 


_id:php82-support/v1_