### PR TITLE
Add Support for Snake Case Property and Method Naming 

### DIFF
--- a/src/ViewModel.php
+++ b/src/ViewModel.php
@@ -20,6 +20,7 @@ abstract class ViewModel implements Arrayable, Responsable
     protected $view = '';
 
     protected $_data = [];
+    protected $snakeCaseMapper = false;
 
     public function toArray(): array
     {
@@ -58,7 +59,7 @@ abstract class ViewModel implements Arrayable, Responsable
                 return $this->shouldIgnore($property->getName());
             })
             ->mapWithKeys(function (ReflectionProperty $property) {
-                return [$property->getName() => $this->{$property->getName()}];
+                return [$this->resolveName($property->getName()) => $this->{$property->getName()}];
             });
 
         $publicMethods = collect($class->getMethods(ReflectionMethod::IS_PUBLIC))
@@ -66,7 +67,7 @@ abstract class ViewModel implements Arrayable, Responsable
                 return $this->shouldIgnore($method->getName());
             })
             ->mapWithKeys(function (ReflectionMethod $method) {
-                return [$method->getName() => $this->createVariableFromMethod($method)];
+                return [$this->resolveName($method->getName()) => $this->createVariableFromMethod($method)];
             });
 
 
@@ -98,5 +99,14 @@ abstract class ViewModel implements Arrayable, Responsable
         }
 
         return Closure::fromCallable([$this, $method->getName()]);
+    }
+
+    protected function resolveName(string $name): string
+    {
+        if (! $this->snakeCaseMapper) {
+            return $name;
+        }
+
+        return Str::snake($name);
     }
 }

--- a/tests/SnakeCaseViewModel.php
+++ b/tests/SnakeCaseViewModel.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Spatie\ViewModels\Tests;
+
+use Spatie\ViewModels\ViewModel;
+use stdClass;
+
+class SnakeCaseViewModel extends ViewModel
+{
+    protected $snakeCaseMapper = true;
+
+    public $dummyProperty = 'abc';
+
+    protected $ignore = ['ignoredMethod'];
+
+    public function __construct()
+    {
+        // This one is here for testing purposes
+    }
+
+    public function publishedPost(): stdClass
+    {
+        return (object) [
+            'title' => 'title',
+            'body' => 'body',
+        ];
+    }
+
+    public function availableCategories(): array
+    {
+        return [
+            (object) [
+                'name' => 'category A',
+            ],
+            (object) [
+                'name' => 'category B',
+            ],
+        ];
+    }
+
+    public function ignoredMethod(): bool
+    {
+        return true;
+    }
+
+    public function callableMethod(string $name): string
+    {
+        return $name;
+    }
+}

--- a/tests/SnakeCaseViewModelTest.php
+++ b/tests/SnakeCaseViewModelTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Http\JsonResponse;
+use Spatie\ViewModels\Tests\SnakeCaseViewModel;
+
+beforeEach(function () {
+    $this->viewModel = new SnakeCaseViewModel();
+});
+
+test('public methods are listed and mapped as snake case', function () {
+    $array = $this->viewModel->toArray();
+
+    expect($array)->toHaveKeys(['published_post', 'available_categories']);
+});
+
+test('public properties are listed and mapped as snake case', function () {
+    $array = $this->viewModel->toArray();
+
+    expect($array)->toHaveKey('dummy_property');
+});
+
+test('values are kept as they are', function () {
+    $array = $this->viewModel->toArray();
+
+    expect($array['published_post']->title)->toEqual('title');
+});
+
+test('callables can be stored', function () {
+    $array = $this->viewModel->toArray();
+
+    expect($array['callable_method']('foo'))->toEqual('foo');
+});
+
+test('to response returns json by default', function () {
+    $response = $this->viewModel->toResponse(createRequest());
+
+    expect($response)->toBeInstanceOf(JsonResponse::class);
+
+    $array = getResponseBody($response);
+
+    expect($array)->toHaveKeys(['published_post', 'available_categories']);
+});


### PR DESCRIPTION
Hello Spatie team,

I use this package to serve data to InertiaJs pages, and it helps me structure and organize my page queries. However, I'd like to keep the component properties in snake case on the front end. Currently, this package does not support it.

I've implemented a solution that works and has test coverage. The solution is inspired by how `laravel-data` package maps class properties to snake case. Since this package still supports PHP 7, I couldn't use PHP Attributes.

An example:

```
class PageViewModel extends ViewModel
{
    protected $snakeCaseMapper = true;
    
    public $dummyProperty = 'abc';
    
    public function publishedPost(): stdClass
    {
        return (object) [
            'title' => 'title',
            'body' => 'body',
        ];
    }
}
```

the result for the array or response will be like this:

```
[
  "dummy_property" => "abc"
  "published_post" =>
       "title": "title"
       "body": "body"
  }
]  
```

I hope you'll consider merging this feature. Thanks!